### PR TITLE
Add Fargate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Introspects [AWS](https://aws.amazon.com) [EC2](https://aws.amazon.com/ec2/) and
 ## Usage
 
 ```ts
-import { getEC2LocalIPv4 } from "@plato/aws-meta";
+import { getInstanceIPV4 } from "@plato/aws-meta";
 
 try {
-	const ip = await getEC2LocalIPv4();
+	const ip = await getInstanceIPV4();
 	// Do something with "ip"
 } catch (e) {
 	// Failed to get local IP

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,3 @@
 export * from "./ec2-metadata";
 export * from "./ecs-metadata";
+export { getInstanceIPV4 }  from "./util";

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,4 +1,19 @@
 import { get } from "http";
+import { getEC2LocalIPv4 } from "./ec2-metadata";
+import { inFargateRuntime, getECSTaskV4IP } from "./ecs-metadata";
+
+/** Fetch the runtime IP address from either ECS, EC2, or Fargate **/
+export function getInstanceIPV4(): Promise<string> {
+	if (inFargateRuntime()) {
+		return getECSTaskV4IP()
+			.catch((e) => {
+				e.message = `could not get fargate container IP: ${e.message}`;
+				throw e;
+			});
+	} else {
+		return getEC2LocalIPv4();
+	}
+}
 
 /** Fetch data via HTTP */
 export function fetch(url: string): Promise<string> {


### PR DESCRIPTION
This MR adds fargate support with the `ECS_CONTAINER_METADATA_URI_V4` endpoint. It also adds a singular entry point for instance IP which determines if the runtime environment is ECS or Fargate, and fetches the IP accordingly. 